### PR TITLE
v2 proposal

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -10,16 +10,32 @@ namespace Microsoft.Extensions.Logging
     public static partial class ConsoleLoggerExtensions
     {
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsole(this Microsoft.Extensions.Logging.ILoggingBuilder builder) { throw null; }
+        [System.ObsoleteAttribute("deprecated.", false)]
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsole(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions> configure) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsole(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.Console.FormattedConsoleLoggerOptions> configure) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsole(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string formatterName) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsoleLogFormatter<TFormatter, TOptions>(this Microsoft.Extensions.Logging.ILoggingBuilder builder) where TFormatter : class, Microsoft.Extensions.Logging.Console.IConsoleLogFormatter where TOptions : class, Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddConsoleLogFormatter<TFormatter, TOptions>(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<TOptions> configure) where TFormatter : class, Microsoft.Extensions.Logging.Console.IConsoleLogFormatter where TOptions : class, Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddDefaultConsoleLogFormatter(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.Console.DefaultConsoleLogFormatterOptions> configure) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddJsonConsoleLogFormatter(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.Console.JsonConsoleLogFormatterOptions> configure) { throw null; }
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddSystemdConsoleLogFormatter(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Microsoft.Extensions.Logging.Console.SystemdConsoleLogFormatterOptions> configure) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Logging.Console
 {
+    public static partial class ConsoleLogFormatterNames
+    {
+        public const string Default = "default";
+        public const string Json = "json";
+        public const string Systemd = "systemd";
+    }
+    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.", false)]
     public enum ConsoleLoggerFormat
     {
         Default = 0,
         Systemd = 1,
     }
+    [System.ObsoleteAttribute("deprecated.", false)]
     public partial class ConsoleLoggerOptions
     {
         public ConsoleLoggerOptions() { }
@@ -31,11 +47,75 @@ namespace Microsoft.Extensions.Logging.Console
         public bool UseUtcTimestamp { get { throw null; } set { } }
     }
     [Microsoft.Extensions.Logging.ProviderAliasAttribute("Console")]
+    [System.ObsoleteAttribute("deprecated.", false)]
     public partial class ConsoleLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
         public ConsoleLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions> options) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
         public void Dispose() { }
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
+    }
+    public partial class DefaultConsoleLogFormatterOptions : Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions
+    {
+        public DefaultConsoleLogFormatterOptions() { }
+        public bool DisableColors { get { throw null; } set { } }
+        public bool IncludeScopes { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
+        public bool MultiLine { get { throw null; } set { } }
+        public string TimestampFormat { get { throw null; } set { } }
+        public bool UseUtcTimestamp { get { throw null; } set { } }
+    }
+    public partial class FormattedConsoleLoggerOptions
+    {
+        public FormattedConsoleLoggerOptions() { }
+        public string FormatterName { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions FormatterOptions { get { throw null; } set { } }
+    }
+    [Microsoft.Extensions.Logging.ProviderAliasAttribute("FormattedConsole")]
+    public partial class FormattedConsoleLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
+    {
+        public FormattedConsoleLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.FormattedConsoleLoggerOptions> options, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.Console.IConsoleLogFormatter> formatters) { }
+        public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
+        public void Dispose() { }
+        public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
+    }
+    public partial interface IConsoleLogFormatter
+    {
+        string Name { get; }
+        void Format<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception exception, System.Func<TState, System.Exception, string> formatter, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider, Microsoft.Extensions.Logging.Console.IConsoleMessageBuilder consoleMessageBuilder);
+        Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions UpdateWith(Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions options);
+    }
+    public partial interface IConsoleLogFormatterOptions
+    {
+        bool IncludeScopes { get; set; }
+        Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get; set; }
+        string TimestampFormat { get; set; }
+        bool UseUtcTimestamp { get; set; }
+    }
+    public partial interface IConsoleMessageBuilder
+    {
+        bool LogAsError { get; set; }
+        Microsoft.Extensions.Logging.Console.IConsoleMessageBuilder Append(string message);
+        Microsoft.Extensions.Logging.Console.IConsoleMessageBuilder Build();
+        void Clear();
+        Microsoft.Extensions.Logging.Console.IConsoleMessageBuilder ResetColor();
+        Microsoft.Extensions.Logging.Console.IConsoleMessageBuilder SetColor(System.ConsoleColor? background, System.ConsoleColor? foreground);
+    }
+    public partial class JsonConsoleLogFormatterOptions : Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions
+    {
+        public JsonConsoleLogFormatterOptions() { }
+        public bool IncludeScopes { get { throw null; } set { } }
+        public System.Text.Json.JsonWriterOptions JsonWriterOptions { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
+        public string TimestampFormat { get { throw null; } set { } }
+        public bool UseUtcTimestamp { get { throw null; } set { } }
+    }
+    public partial class SystemdConsoleLogFormatterOptions : Microsoft.Extensions.Logging.Console.IConsoleLogFormatterOptions
+    {
+        public SystemdConsoleLogFormatterOptions() { }
+        public bool IncludeScopes { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
+        public string TimestampFormat { get { throw null; } set { } }
+        public bool UseUtcTimestamp { get { throw null; } set { } }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.Logging.Console.cs" />
+    <ProjectReference Include="..\..\System.Text.Json\ref\System.Text.Json.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Logging.Abstractions\ref\Microsoft.Extensions.Logging.Abstractions.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Logging\ref\Microsoft.Extensions.Logging.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Options\ref\Microsoft.Extensions.Options.csproj" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/AnsiLogConsole.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/AnsiLogConsole.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Extensions.Logging.Console
     /// </summary>
     internal class AnsiLogConsole : IConsole
     {
+        private const string DefaultForegroundColor = "\x1B[39m\x1B[22m";
+        private const string DefaultBackgroundColor = "\x1B[49m";
+
         private readonly StringBuilder _outputBuilder;
         private readonly IAnsiSystemConsole _systemConsole;
 
@@ -94,7 +97,7 @@ namespace Microsoft.Extensions.Logging.Console
                 case ConsoleColor.White:
                     return "\x1B[1m\x1B[37m";
                 default:
-                    return "\x1B[39m\x1B[22m"; // default foreground color
+                    return DefaultForegroundColor; // default foreground color
             }
         }
 
@@ -119,7 +122,7 @@ namespace Microsoft.Extensions.Logging.Console
                 case ConsoleColor.White:
                     return "\x1B[47m";
                 default:
-                    return "\x1B[49m"; // Use default background color
+                    return DefaultBackgroundColor; // Use default background color
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
@@ -5,8 +5,17 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -20,8 +29,20 @@ namespace Microsoft.Extensions.Logging
         {
             builder.AddConfiguration();
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ConsoleLoggerProvider>());
-            LoggerProviderOptions.RegisterProviderOptions<ConsoleLoggerOptions, ConsoleLoggerProvider>(builder.Services);
+            builder.AddConsoleLogFormatter<JsonConsoleLogFormatter, JsonConsoleLogFormatterOptions>();
+            builder.AddConsoleLogFormatter<SystemdConsoleLogFormatter, SystemdConsoleLogFormatterOptions>();
+            builder.AddConsoleLogFormatter<DefaultConsoleLogFormatter, DefaultConsoleLogFormatterOptions>();
+
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, FormattedConsoleLoggerProvider>());
+            LoggerProviderOptions.RegisterProviderOptions<FormattedConsoleLoggerOptions, FormattedConsoleLoggerProvider>(builder.Services);
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .Build();
+
+            builder.Services.AddOptions<FormattedConsoleLoggerOptions>().Bind(configuration.GetSection("Logging:Console"));
+            builder.Services.Configure<FormattedConsoleLoggerOptions>(configuration.GetSection("Logging:Console"));
+
             return builder;
         }
 
@@ -30,6 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
         /// <param name="configure">A delegate to configure the <see cref="ConsoleLogger"/>.</param>
+        [System.ObsoleteAttribute("deprecated.", false)]
         public static ILoggingBuilder AddConsole(this ILoggingBuilder builder, Action<ConsoleLoggerOptions> configure)
         {
             if (configure == null)
@@ -41,6 +63,159 @@ namespace Microsoft.Extensions.Logging
             builder.Services.Configure(configure);
 
             return builder;
+        }
+
+        /// <summary>
+        /// Adds a console logger named 'Console' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">A delegate to configure the <see cref="ConsoleLogger"/>.</param>
+        public static ILoggingBuilder AddConsole(this ILoggingBuilder builder, Action<FormattedConsoleLoggerOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddConsole();
+            builder.Services.Configure(configure);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a console logger named 'Console' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="formatterName">Formatter name selected for the <see cref="ConsoleLogger"/>.</param>
+        public static ILoggingBuilder AddConsole(this ILoggingBuilder builder, string formatterName)
+        {
+            if (formatterName == null)
+            {
+                throw new ArgumentNullException(nameof(formatterName));
+            }
+
+            Action<FormattedConsoleLoggerOptions> configure = (options) => { options.FormatterName = formatterName; };
+            return builder.AddConsole(configure);
+        }
+        
+        /// <summary>
+        /// Add and configure a console log formatter named 'json' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">A delegate to configure the <see cref="ConsoleLogger"/> options for the built-in default log formatter.</param>
+        public static ILoggingBuilder AddDefaultConsoleLogFormatter(this ILoggingBuilder builder, Action<DefaultConsoleLogFormatterOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddConsole();
+            builder.Services.Configure(configure);
+
+            Action<FormattedConsoleLoggerOptions> configureFormatter = (options) => { options.FormatterName = ConsoleLogFormatterNames.Default; };
+            builder.Services.Configure(configureFormatter);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Add and configure a console log formatter named 'json' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">A delegate to configure the <see cref="ConsoleLogger"/> options for the built-in json log formatter.</param>
+        public static ILoggingBuilder AddJsonConsoleLogFormatter(this ILoggingBuilder builder, Action<JsonConsoleLogFormatterOptions> configure)
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddConsole();
+            builder.Services.Configure(configure);
+
+            Action<FormattedConsoleLoggerOptions> configureFormatter = (options) => { options.FormatterName = ConsoleLogFormatterNames.Json; };
+            builder.Services.Configure(configureFormatter);
+
+            return builder;
+        }
+        
+        /// <summary>
+        /// Add and configure a console log formatter named 'systemd' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">A delegate to configure the <see cref="ConsoleLogger"/> options for the built-in systemd log formatter.</param>
+        public static ILoggingBuilder AddSystemdConsoleLogFormatter(this ILoggingBuilder builder, Action<SystemdConsoleLogFormatterOptions> configure)
+         {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddConsole();
+            builder.Services.Configure(configure);
+
+            Action<FormattedConsoleLoggerOptions> configureFormatter = (options) => { options.FormatterName = ConsoleLogFormatterNames.Systemd; };
+            builder.Services.Configure(configureFormatter);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a custom console logger formatter 'TFormatter' to be configured with options 'TOptions'.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        public static ILoggingBuilder AddConsoleLogFormatter<TFormatter, TOptions>(this ILoggingBuilder builder)
+            where TOptions : class, IConsoleLogFormatterOptions
+            where TFormatter : class, IConsoleLogFormatter
+        {
+            builder.AddConfiguration();
+
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConsoleLogFormatter, TFormatter>());
+            builder.Services.AddSingleton<IConfigureOptions<TOptions>, LogFormatterOptionsSetup<TFormatter, TOptions>>();
+            builder.Services.AddSingleton<IOptionsChangeTokenSource<TOptions>, LoggerProviderOptionsChangeTokenSource<TOptions, TFormatter>>();
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .Build();
+            builder.Services.AddOptions<TOptions>().Bind(configuration.GetSection("Logging:Console:FormatterOptions"));
+            builder.Services.Configure<TOptions>(configuration.GetSection("Logging:Console:FormatterOptions"));
+
+            // todo: configure and bind Console:Loggimg:FormatterName
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a custom console logger formatter 'TFormatter' to be configured with options 'TOptions'.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">A delegate to configure options 'TOptions' for custom formatter 'TFormatter'.</param>
+        public static ILoggingBuilder AddConsoleLogFormatter<TFormatter, TOptions>(this ILoggingBuilder builder, Action<TOptions> configure)
+            where TOptions : class, IConsoleLogFormatterOptions
+            where TFormatter : class, IConsoleLogFormatter
+        {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            builder.AddConsoleLogFormatter<TFormatter, TOptions>();
+
+            builder.Services.Configure(configure);
+
+            return builder;
+        }
+    }
+
+    internal class LogFormatterOptionsSetup<TFormatter, TOptions> : ConfigureFromConfigurationOptions<TOptions> 
+            where TOptions : class
+            where TFormatter : class, IConsoleLogFormatter
+    {
+        public LogFormatterOptionsSetup(ILoggerProviderConfiguration<TFormatter> providerConfiguration)
+            : base(providerConfiguration.Configuration)
+        {
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Extensions.Logging.Console
     /// <summary>
     /// Format of <see cref="ConsoleLogger" /> messages.
     /// </summary>
+    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.", false)]
     public enum ConsoleLoggerFormat
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Logging.Console
     /// <summary>
     /// Options for a <see cref="ConsoleLogger"/>.
     /// </summary>
+    [System.ObsoleteAttribute("deprecated.", false)]
     public class ConsoleLoggerOptions
     {
         private ConsoleLoggerFormat _format = ConsoleLoggerFormat.Default;
@@ -22,7 +23,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// Disables colors when <see langword="true" />.
         /// </summary>
         public bool DisableColors { get; set; }
-
+        
         /// <summary>
         /// Gets or sets log message format. Defaults to <see cref="ConsoleLoggerFormat.Default" />.
         /// </summary>
@@ -54,4 +55,25 @@ namespace Microsoft.Extensions.Logging.Console
         /// </summary>
         public bool UseUtcTimestamp { get; set; }
     }
+
+    public class FormattedConsoleLoggerOptions
+    {
+        private string _format = ConsoleLogFormatterNames.Default;
+        private IConsoleLogFormatterOptions _options = new DefaultConsoleLogFormatterOptions();
+        public FormattedConsoleLoggerOptions() { }
+        public string FormatterName { 
+            get => _format;
+            set
+            {
+                _format = value;
+            }
+        }
+        public IConsoleLogFormatterOptions FormatterOptions { 
+            get => _options;
+            set
+            {
+                _options = value;
+            }
+        }
+    } 
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Logging.Console
     /// A provider of <see cref="ConsoleLogger"/> instances.
     /// </summary>
     [ProviderAlias("Console")]
+    [System.ObsoleteAttribute("deprecated.", false)]
     public class ConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         private readonly IOptionsMonitor<ConsoleLoggerOptions> _options;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleMessageBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleMessageBuilder.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class DummyConsoleBuilder : IConsoleMessageBuilder
+    {
+        private ConsoleColor? DefaultForegroundColor = ConsoleColor.Gray; // "\x1B[39m\x1B[22m";
+        private ConsoleColor? DefaultBackgroundColor = ConsoleColor.Black; //"\x1B[49m";
+        private FormattedConsoleLoggerProcessor _queueProcessor;
+        
+        public DummyConsoleBuilder(FormattedConsoleLoggerProcessor queueProcessor, bool logAsError = false)
+        {
+            _queueProcessor = queueProcessor;
+            LogAsError = logAsError;
+        }
+
+        public IConsoleMessageBuilder ResetColor()
+        {
+            return SetColor(DefaultBackgroundColor, DefaultForegroundColor);
+        }
+
+        public IConsoleMessageBuilder SetColor(ConsoleColor? background, ConsoleColor?  foreground)
+        {
+            if (WouldBeAColorChange(background, foreground))
+            {
+                var logBuilder = _sb;
+                _sb = null;
+
+                if (logBuilder != null && logBuilder.Length != 0)
+                {
+                    var message = logBuilder.ToString();
+                    _queueProcessor.EnqueueMessage(new ConsoleMessage(message, _colorSetting.bg, _colorSetting.fg, LogAsError));
+                    logBuilder.Clear();
+
+                    if (logBuilder.Capacity > 1024)
+                    {
+                        logBuilder.Capacity = 1024;
+                    }
+                }
+                _sb = logBuilder;
+
+                _colorSetting.bg = background;
+                _colorSetting.fg = foreground;
+            }
+            return this;
+        }
+        private bool WouldBeAColorChange(ConsoleColor? background, ConsoleColor?  foreground)
+        {
+            // compare against _colorSettings
+            // throw new NotImplementedException("TODO: " + nameof(WouldBeAColorChange));
+            return true;
+        }
+        private (ConsoleColor? bg, ConsoleColor? fg) _colorSetting = (null, null);
+
+        [ThreadStatic]
+        private static StringBuilder _sb = new StringBuilder();
+
+        public IConsoleMessageBuilder Append(string message)
+        {
+            var logBuilder = _sb;
+            _sb = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+            logBuilder.Append(message);
+
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _sb = logBuilder;
+            return this;
+        }
+
+        public bool LogAsError { get; set; }
+
+        public IConsoleMessageBuilder Build()
+        {
+            var logBuilder = _sb;
+            _sb = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+            var message = logBuilder.ToString();
+            _queueProcessor.EnqueueMessage(new ConsoleMessage(message, _colorSetting.bg, _colorSetting.fg, LogAsError));
+
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _sb = logBuilder;
+            ResetColor();
+            return this;
+        }
+
+        public void Clear()
+        {
+            var logBuilder = _sb;
+            _sb = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _sb = logBuilder;
+            ResetColor();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLogger.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.CodeDom;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class FormattedConsoleLogger : ILogger
+    {
+
+        private readonly string _name;
+        private readonly FormattedConsoleLoggerProcessor _queueProcessor;
+        private readonly ConcurrentDictionary<string, IConsoleLogFormatter> _formatters;
+        private readonly IConsoleMessageBuilder _consoleMessageBuilder;
+
+        internal FormattedConsoleLogger(string name, FormattedConsoleLoggerProcessor loggerProcessor, ConcurrentDictionary<string, IConsoleLogFormatter> formatters, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            _name = name;
+            _queueProcessor = loggerProcessor;
+            _formatters = formatters;
+            _consoleMessageBuilder = consoleMessageBuilder;
+        }
+
+        internal IExternalScopeProvider ScopeProvider { get; set; }
+
+        internal IConsoleLogFormatterOptions FormatterOptions { get; set; }
+        internal IConsoleLogFormatter Formatter { get; set; }
+
+        private FormattedConsoleLoggerOptions _formattedConsoleLoggerOptions;
+
+        internal FormattedConsoleLoggerOptions Options {
+            get 
+            {
+                return _formattedConsoleLoggerOptions;
+            } 
+            set 
+            {
+                if (
+                    value.FormatterName == null ||
+                    (
+                        !_formatters.TryGetValue(value.FormatterName, out IConsoleLogFormatter logFormatter) &&
+                        !_formatters.TryGetValue(value.FormatterName?.ToLower(), out logFormatter))
+                    )
+                {
+                    logFormatter = _formatters[ConsoleLogFormatterNames.Default];
+                }
+                // update Formatter using FormatterName when Options changes
+                Formatter = logFormatter;
+
+                // update Formatter.FormatterOptions when options.FormatterOptions changes
+                FormatterOptions = Formatter.UpdateWith(value.FormatterOptions);
+
+                _formattedConsoleLoggerOptions = value;
+            }
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (formatter == null)
+            {
+                throw new ArgumentNullException(nameof(formatter));
+            }
+
+            var message = formatter(state, exception);
+            if (!string.IsNullOrEmpty(message) || exception != null)
+            {
+                Formatter.Format(logLevel, _name, eventId.Id, state, exception, formatter, ScopeProvider, _consoleMessageBuilder);
+                _consoleMessageBuilder.Clear();
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return logLevel != LogLevel.None;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => ScopeProvider?.Push(state) ?? NullScope.Instance;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLoggerProcessor.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class FormattedConsoleLoggerProcessor : IDisposable
+    {
+        private const int _maxQueuedMessages = 1024;
+
+        private readonly BlockingCollection<ConsoleMessage> _messageQueue = new BlockingCollection<ConsoleMessage>(_maxQueuedMessages);
+        private readonly Thread _outputThread;
+
+        public IConsole Console;
+        public IConsole ErrorConsole;
+
+        public FormattedConsoleLoggerProcessor()
+        {
+            // Start Console message queue processor
+            _outputThread = new Thread(ProcessLogQueue)
+            {
+                IsBackground = true,
+                Name = "Console logger queue processing thread"
+            };
+            _outputThread.Start();
+        }
+
+        public virtual void EnqueueMessage(ConsoleMessage message)
+        {
+            if (!_messageQueue.IsAddingCompleted)
+            {
+                try
+                {
+                    _messageQueue.Add(message);
+                    return;
+                }
+                catch (InvalidOperationException) { }
+            }
+
+            // Adding is completed so just log the message
+            try
+            {
+                WriteMessage(message);            
+            }
+            catch (Exception) { }
+        }
+
+        // for testing
+        internal virtual void WriteMessage(ConsoleMessage message)
+        {
+            var console = message.LogAsError ? ErrorConsole : Console;
+            console.Write(message.Message, message.Background, message.Foreground);
+            console.Flush();
+        }
+
+        private void ProcessLogQueue()
+        {
+            try
+            {
+                foreach (var message in _messageQueue.GetConsumingEnumerable())
+                {
+                    WriteMessage(message);
+                }
+            }
+            catch
+            {
+                try
+                {
+                    _messageQueue.CompleteAdding();
+                }
+                catch { }
+            }
+        }
+
+        public void Dispose()
+        {
+            _messageQueue.CompleteAdding();
+
+            try
+            {
+                _outputThread.Join(1500); // with timeout in-case Console is locked by user input
+            }
+            catch (ThreadStateException) { }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/FormattedConsoleLoggerProvider.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    /// <summary>
+    /// A provider of <see cref="FormattedConsoleLogger"/> instances.
+    /// </summary>
+    [ProviderAlias("FormattedConsole")]
+    public class FormattedConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
+    {
+        private FormattedConsoleLoggerOptions _options;
+        private readonly ConcurrentDictionary<string, FormattedConsoleLogger> _loggers;
+        private readonly ConcurrentDictionary<string, IConsoleLogFormatter> _formatters;
+        private readonly FormattedConsoleLoggerProcessor _messageQueue;
+
+        private IDisposable _optionsReloadToken;
+        private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;
+        private readonly IConsoleMessageBuilder _consoleMessageBuilder;
+
+        /// <summary>
+        /// Creates an instance of <see cref="ConsoleLoggerProvider"/>.
+        /// </summary>
+        /// <param name="options">The options to create <see cref="FormattedConsoleLogger"/> instances with.</param>
+        /// <param name="formatters">Log formatters added for <see cref="FormattedConsoleLogger"/> insteaces.</param>
+        public FormattedConsoleLoggerProvider(IOptionsMonitor<FormattedConsoleLoggerOptions> options, IEnumerable<IConsoleLogFormatter> formatters)
+        {
+            _options = options.CurrentValue;
+            _loggers = new ConcurrentDictionary<string, FormattedConsoleLogger>();
+            _formatters = new ConcurrentDictionary<string, IConsoleLogFormatter>(formatters.ToDictionary(f => f.Name)); 
+
+            ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+
+            _messageQueue = new FormattedConsoleLoggerProcessor();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                _messageQueue.Console = new WindowsLogConsole();
+                _messageQueue.ErrorConsole = new WindowsLogConsole(stdErr: true);
+            }
+            else
+            {
+                _messageQueue.Console = new AnsiLogConsole(new AnsiSystemConsole());
+                _messageQueue.ErrorConsole = new AnsiLogConsole(new AnsiSystemConsole(stdErr: true));
+            }
+            _consoleMessageBuilder = new DummyConsoleBuilder(_messageQueue);
+        }
+
+        // warning:  ReloadLoggerOptions can be called before the ctor completed,... before registering all of the state used in this method need to be initialized
+        private void ReloadLoggerOptions(FormattedConsoleLoggerOptions options)
+        {
+            foreach (var logger in _loggers)
+            {
+                logger.Value.Options = options;
+                options.FormatterOptions = logger.Value.FormatterOptions;
+                logger.Value.Options = options;
+            }
+        }
+
+        /// <inheritdoc />
+        public ILogger CreateLogger(string name)
+        {
+            return _loggers.GetOrAdd(name, loggerName => new FormattedConsoleLogger(name, _messageQueue, _formatters, _consoleMessageBuilder)
+            {
+                ScopeProvider = _scopeProvider,
+                Options = _options
+            });
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _optionsReloadToken?.Dispose();
+            _messageQueue.Dispose();
+        }
+
+        /// <inheritdoc />
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            _scopeProvider = scopeProvider;
+
+            foreach (var logger in _loggers)
+            {
+                logger.Value.ScopeProvider = _scopeProvider;
+            }
+
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ConsoleLogFormatterNames.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ConsoleLogFormatterNames.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public static class ConsoleLogFormatterNames
+    {
+        public const string Default = "default";
+        public const string Json = "json";
+        public const string Systemd = "systemd";
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultConsoleLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultConsoleLogFormatter.cs
@@ -1,0 +1,423 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class DefaultConsoleLogFormatter : IConsoleLogFormatter, IDisposable
+    {
+        private static readonly string _loglevelPadding = ": ";
+        private static readonly string _messagePadding;
+        private static readonly string _newLineWithMessagePadding;
+        private IDisposable _optionsReloadToken;
+
+        // ConsoleColor does not have a value to specify the 'Default' color
+        private readonly ConsoleColor? DefaultConsoleColor = null;
+
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+
+        static DefaultConsoleLogFormatter()
+        {
+            var logLevelString = GetLogLevelString(LogLevel.Information);
+            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
+            _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
+        }
+
+        public DefaultConsoleLogFormatter(IOptionsMonitor<DefaultConsoleLogFormatterOptions> options)
+        {
+            FormatterOptions = options.CurrentValue;
+            ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+        }
+
+        private void ReloadLoggerOptions(DefaultConsoleLogFormatterOptions options)
+        {
+            FormatterOptions = options;
+        }
+
+        public void Dispose()
+        {
+            _optionsReloadToken?.Dispose();
+        }
+
+        public string Name => ConsoleLogFormatterNames.Default;
+
+        internal DefaultConsoleLogFormatterOptions FormatterOptions { get; set; }
+
+        public IConsoleLogFormatterOptions UpdateWith(IConsoleLogFormatterOptions options)
+        {
+            if (options is DefaultConsoleLogFormatterOptions jOptions)
+                FormatterOptions = jOptions;
+            else
+            {
+                FormatterOptions.IncludeScopes = options.IncludeScopes;
+                // etc.
+            }
+            return FormatterOptions;
+        }
+        public void Format<TState>(LogLevel logLevel, string logName, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            var message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message) && exception == null)
+            {
+                return;
+            }
+            if (!FormatterOptions.MultiLine)
+            {
+                FormatHelperCompact(logLevel, logName, eventId.Id, message, exception, scopeProvider, state, consoleMessageBuilder);
+                return;
+            }
+            Format(logLevel, logName, eventId.Id, message, exception, scopeProvider, consoleMessageBuilder);
+        }
+
+        private void FormatHelperCompact<TState>(LogLevel logLevel, string logName, int eventId, string message, Exception exception, IExternalScopeProvider scopeProvider, TState scope, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            var messages = new List<ConsoleMessage>();
+
+            var logLevelColors = GetLogLevelConsoleColors(logLevel);
+            var logLevelString = GetLogLevelString(logLevel);
+
+            string timestamp = null;
+            var timestampFormat = FormatterOptions.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime();
+                timestamp = dateTime.ToString(timestampFormat);
+            }
+            if (timestamp != null)
+            {
+                consoleMessageBuilder
+                    .Append(timestamp + " ");
+            }
+            if (logLevelString != null)
+            {
+                consoleMessageBuilder
+                    .SetColor(logLevelColors.Background, logLevelColors.Foreground)
+                    .Append(logLevelString + " ")
+                    .ResetColor();
+            }
+
+            consoleMessageBuilder
+                .Append($"{logName}[{eventId}] ");
+            string originalFormat = null;
+            int count = 0;
+
+            if (scope != null)
+            {
+                if (scope is IReadOnlyList<KeyValuePair<string, object>> kvpsx)
+                {
+                    var strings = new List<KeyValuePair<string, object>>();
+                    foreach (var kvp in kvpsx)
+                    {
+                        if (kvp.Key.Contains("{OriginalFormat}"))
+                        {
+                            originalFormat = kvp.Value.ToString();
+                        }
+                        else
+                        {
+                            strings.Add(kvp);
+                        }
+                    }
+                    int prevIndex = 0;
+                    if (originalFormat != null)
+                    {
+                        foreach (var kvp in kvpsx)
+                        {
+                            if (!kvp.Key.Contains("{OriginalFormat}"))
+                            {
+                                var curIndex = originalFormat.IndexOf("{" + strings.ElementAt(count).Key + "}");
+                                if (curIndex != -1)
+                                {
+                                    var curString = originalFormat.Substring(prevIndex, curIndex - prevIndex);
+                                    
+                                    consoleMessageBuilder
+                                        .Append(curString)
+                                        // TODO: when DisableColors is true, also uncolor the inner var colors
+                                        .SetColor(null, ConsoleColor.Cyan)
+                                        .Append(strings.ElementAt(count).Value.ToString())
+                                        .ResetColor();
+                                    prevIndex += curIndex + strings.ElementAt(count).Key.Length + 2;
+                                    count++;
+                                }
+                            }
+                        }
+                    }
+                }
+                else if (scope is IReadOnlyList<KeyValuePair<string, string>> kvps)
+                {
+                    var strings = new List<KeyValuePair<string, string>>();
+                    foreach (var kvp in kvps)
+                    {
+                        if (kvp.Key.Contains("{OriginalFormat}"))
+                        {
+                            originalFormat = kvp.Value;
+                        }
+                        else
+                        {
+                            strings.Add(kvp);
+                        }
+                    }
+                    int prevIndex = 0;
+                    if (originalFormat != null)
+                    {
+                        foreach (var kvp in kvps)
+                        {
+                            if (!kvp.Key.Contains("{OriginalFormat}"))
+                            {
+                                var curIndex = originalFormat.IndexOf("{" + strings.ElementAt(count).Key + "}");
+                                if (curIndex != -1)
+                                {
+                                    var curString = originalFormat.Substring(prevIndex, curIndex - prevIndex);
+
+                                    consoleMessageBuilder
+                                        .ResetColor()
+                                        .Append(curString)
+                                        // TODO: when DisableColors is true, also uncolor the inner var colors
+                                        .SetColor(null, ConsoleColor.Cyan)
+                                        .Append(strings.ElementAt(count).Value)
+                                        .ResetColor();
+                                    prevIndex += curIndex + strings.ElementAt(count).Key.Length + 2;
+                                    count++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                if (originalFormat == null)
+                {
+                    consoleMessageBuilder
+                        .ResetColor()
+                        .Append(message);
+                }
+                else if (count == 0)
+                {
+                    consoleMessageBuilder
+                        .ResetColor()
+                        .Append(originalFormat);
+                }
+            }
+
+            consoleMessageBuilder.Append(" ");
+            GetScopeInformation(scopeProvider, consoleMessageBuilder);
+
+            if (exception != null)
+            {
+                // exception message
+                consoleMessageBuilder.ResetColor().Append(" ")
+                    .Append(exception.ToString().Replace(Environment.NewLine, " "));
+                // TODO: try to improve readability for exception message.
+                // TODO: maybe use Compact as default?
+            }
+            consoleMessageBuilder.Append(Environment.NewLine);
+            consoleMessageBuilder.LogAsError =  logLevel >= FormatterOptions.LogToStandardErrorThreshold;
+            consoleMessageBuilder
+                .Build();
+        }
+
+        // IConsoleMessageBuilder // allocates a string 
+        // Append(string messagee)
+        // SetColor(xx)
+        // ToString()
+
+        private void Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            var logBuilder = _logBuilder;
+            _logBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+
+            // Example:
+            // INFO: ConsoleApp.Program[10]
+            //       Request received
+
+            var logLevelColors = GetLogLevelConsoleColors(logLevel);
+            var logLevelString = GetLogLevelString(logLevel);
+            // category and event id
+            logBuilder.Append(_loglevelPadding);
+            logBuilder.Append(logName);
+            logBuilder.Append("[");
+            logBuilder.Append(eventId);
+            logBuilder.AppendLine("]");
+
+            // scope information
+            GetScopeInformation(scopeProvider, consoleMessageBuilder);
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                // message
+                logBuilder.Append(_messagePadding);
+
+                var len = logBuilder.Length;
+                logBuilder.AppendLine(message);
+                logBuilder.Replace(Environment.NewLine, _newLineWithMessagePadding, len, message.Length);
+            }
+
+            // Example:
+            // System.InvalidOperationException
+            //    at Namespace.Class.Function() in File:line X
+            if (exception != null)
+            {
+                // exception message
+                logBuilder.AppendLine(exception.ToString());
+            }
+
+            string timestamp = null;
+            var timestampFormat = FormatterOptions.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime();
+                timestamp = dateTime.ToString(timestampFormat);
+            }
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+            
+            consoleMessageBuilder.LogAsError = logLevel >= FormatterOptions.LogToStandardErrorThreshold;
+            if (timestamp != null)
+            {
+                consoleMessageBuilder.SetColor(DefaultConsoleColor, DefaultConsoleColor).Append(timestamp);
+            }
+            if (logLevelString != null)
+            {
+                consoleMessageBuilder.SetColor(logLevelColors.Background, logLevelColors.Foreground).Append(logLevelString);
+            }
+            consoleMessageBuilder
+                .SetColor(DefaultConsoleColor, DefaultConsoleColor)
+                .Append(formattedMessage)
+                .Build();
+        }
+
+        private DateTime GetCurrentDateTime()
+        {
+            return FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                    return "trce";
+                case LogLevel.Debug:
+                    return "dbug";
+                case LogLevel.Information:
+                    return "info";
+                case LogLevel.Warning:
+                    return "warn";
+                case LogLevel.Error:
+                    return "fail";
+                case LogLevel.Critical:
+                    return "crit";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
+        {
+            if (FormatterOptions.DisableColors)
+            {
+                return new ConsoleColors(null, null);
+            }
+
+            // We must explicitly set the background color if we are setting the foreground color,
+            // since just setting one can look bad on the users console.
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return new ConsoleColors(ConsoleColor.White, ConsoleColor.Red);
+                case LogLevel.Error:
+                    return new ConsoleColors(ConsoleColor.Black, ConsoleColor.Red);
+                case LogLevel.Warning:
+                    return new ConsoleColors(ConsoleColor.Yellow, ConsoleColor.Black);
+                case LogLevel.Information:
+                    return new ConsoleColors(ConsoleColor.DarkGreen, ConsoleColor.Black);
+                case LogLevel.Debug:
+                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
+                case LogLevel.Trace:
+                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
+                default:
+                    return new ConsoleColors(DefaultConsoleColor, DefaultConsoleColor);
+            }
+        }
+
+        private void GetScopeInformation(IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            if (FormatterOptions.IncludeScopes && scopeProvider != null)
+            {
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    state
+                        .ResetColor().Append("=> ")
+                        .SetColor(null, ConsoleColor.DarkGray)
+                        .Append(scope.ToString())
+                        .ResetColor()
+                        .Append(" ");
+
+                }, consoleMessageBuilder);
+            }
+        }
+
+        private void GetScopeInformation(StringBuilder stringBuilder, IExternalScopeProvider scopeProvider)
+        {
+            if (FormatterOptions.IncludeScopes && scopeProvider != null)
+            {
+                var initialLength = stringBuilder.Length;
+
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    var (builder, paddAt) = state;
+                    var padd = paddAt == builder.Length;
+                    if (padd)
+                    {
+                        builder.Append(_messagePadding);
+                        builder.Append("=> ");
+                    }
+                    else
+                    {
+                        builder.Append(" => ");
+                    }
+                    builder.Append(scope);
+                }, (stringBuilder, initialLength));
+
+                if (stringBuilder.Length > initialLength)
+                {
+                    stringBuilder.AppendLine();
+                }
+            }
+        }
+
+        private readonly struct ConsoleColors
+        {
+            public ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
+            {
+                Foreground = foreground;
+                Background = background;
+            }
+
+            public ConsoleColor? Foreground { get; }
+
+            public ConsoleColor? Background { get; }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultConsoleLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultConsoleLogFormatterOptions.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    /// <summary>
+    /// Options for the built-in default console log formatter.
+    /// </summary>
+    public class DefaultConsoleLogFormatterOptions : IConsoleLogFormatterOptions
+    {
+        public DefaultConsoleLogFormatterOptions() { }
+        
+        /// <summary>
+        /// Disables colors when <see langword="true" />.
+        /// </summary>
+        public bool DisableColors { get; set; }
+
+        /// <summary>
+        /// Includes scopes when <see langword="true" />.
+        /// </summary>
+        public bool IncludeScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets value indicating the minimum level of messages that would get written to <c>Console.Error</c>.
+        /// </summary>
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get; set; }
+        
+        /// <summary>
+        /// When <see langword="false" />, the entire message gets logged in a single line.
+        /// </summary>
+        public bool MultiLine { get; set; }
+        
+        /// <summary>
+        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// </summary>
+        public string TimestampFormat { get; set; }
+        
+        /// <summary>
+        /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
+        /// </summary>
+        public bool UseUtcTimestamp { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/IConsoleLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/IConsoleLogFormatter.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public interface IConsoleLogFormatter
+    {
+
+        /// <summary>
+        /// Gets the name associated with the console log formatter.
+        /// </summary>
+        string Name { get; }
+
+        IConsoleLogFormatterOptions UpdateWith(IConsoleLogFormatterOptions options);
+
+        /// <summary>
+        /// Formats a log message at the specified log level.
+        /// </summary>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="logName">The log name.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">Function to create a <see cref="string"/> message of the <paramref name="state"/> and <paramref name="exception"/>.</param>
+        /// <param name="scopeProvider">The provider of scope data.</param>
+        /// <param name="consoleMessageBuilder">The provider of scope data.</param>
+        /// <typeparam name="TState">The type of the object to be written.</typeparam>
+        void Format<TState>(LogLevel logLevel, string logName, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder);
+    }
+
+    public interface IConsoleLogFormatterOptions
+    {
+        /// <summary>
+        /// Includes scopes when <see langword="true" />.
+        /// </summary>
+        bool IncludeScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets value indicating the minimum level of messages that would get written to <c>Console.Error</c>.
+        /// </summary>
+        Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get; set; }
+        
+        /// <summary>
+        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// </summary>
+        string TimestampFormat { get; set; }
+        
+        /// <summary>
+        /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
+        /// </summary>
+        bool UseUtcTimestamp { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonConsoleLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonConsoleLogFormatter.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class JsonConsoleLogFormatter : IConsoleLogFormatter, IDisposable
+    {
+        private IDisposable _optionsReloadToken;
+        
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+
+        public JsonConsoleLogFormatter(IOptionsMonitor<JsonConsoleLogFormatterOptions> options)
+        {
+            FormatterOptions = options.CurrentValue;
+            ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+        }
+
+        public string Name => ConsoleLogFormatterNames.Json;
+
+        private string WriteJson(LogLevel logLevel, string logName, int eventId, string message, Exception exception, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)//long[] extraData)
+        {
+            const int DefaultBufferSize = 1024;
+            var output = new ArrayBufferWriter<byte>(DefaultBufferSize);
+            using (var writer = new Utf8JsonWriter(output, FormatterOptions.JsonWriterOptions))
+            {
+                writer.WriteStartObject();
+
+
+                string timestamp = null;
+                var timestampFormat = FormatterOptions.TimestampFormat;
+                if (timestampFormat != null)
+                {
+                    var dateTime = FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+                    timestamp = dateTime.ToString(timestampFormat);
+                }
+                writer.WriteString("timestamp", timestamp);
+                writer.WriteNumber("eventId", eventId);
+                writer.WriteString("logLevel", GetLogLevelString(logLevel));
+                writer.WriteString("category", logName);
+                writer.WriteString("message", message);
+
+                if (exception != null)
+                {
+                    writer.WriteStartObject("exception");
+                    writer.WriteString("message", exception.Message.ToString());
+                    writer.WriteString("type", exception.GetType().ToString());
+                    writer.WriteStartArray("stackTrace");
+                    if (exception?.StackTrace != null)
+                    {
+                        foreach (var xx in exception?.StackTrace?.Split(Environment.NewLine))
+                        {
+                            JsonSerializer.Serialize<string>(writer, xx);
+                        }
+                    }
+                    writer.WriteEndArray();
+                    writer.WriteNumber("hResult", exception.HResult);
+                    writer.WriteEndObject();
+                }
+
+                GetScopeInformation(writer, scopeProvider);
+
+                writer.WriteEndObject();
+
+                writer.Flush();
+            }
+            return Encoding.UTF8.GetString(output.WrittenMemory.Span);
+        }
+
+        public void Format<TState>(LogLevel logLevel, string logName, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            var message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message) && exception == null)
+            {
+                return;
+            }
+            var logBuilder = _logBuilder;
+            _logBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+
+            logBuilder.Append(WriteJson(logLevel, logName, eventId.Id, message, exception, scopeProvider, consoleMessageBuilder));
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+            
+            consoleMessageBuilder.LogAsError =  logLevel >= FormatterOptions.LogToStandardErrorThreshold;
+            consoleMessageBuilder
+                .Append(formattedMessage)
+                .Append(Environment.NewLine)
+                .Build();
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                    return "json_trace";
+                case LogLevel.Debug:
+                    return "json_debug";
+                case LogLevel.Information:
+                    return "json_info";
+                case LogLevel.Warning:
+                    return "json_warn";
+                case LogLevel.Error:
+                    return "json_fail";
+                case LogLevel.Critical:
+                    return "json_critical";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private void GetScopeInformation(Utf8JsonWriter writer, IExternalScopeProvider scopeProvider)
+        {
+            try
+            {
+                if (FormatterOptions.IncludeScopes && scopeProvider != null)
+                {
+                    writer.WriteStartObject("scopes");
+                    scopeProvider.ForEachScope((scope, state) =>
+                    {
+                        if (scope is IReadOnlyList<KeyValuePair<string, object>> kvps)
+                        {
+                            foreach (var kvp in kvps)
+                            {
+                                if (kvp.Value is string ss)
+                                    state.WriteString(kvp.Key, ss);
+                                else
+                                if (kvp.Value is int ii)
+                                    state.WriteNumber(kvp.Key, ii);
+                                else
+                                {
+                                    // check how this work
+                                    state.WritePropertyName(kvp.Key);
+                                    JsonSerializer.Serialize(state, kvp.Value);
+                                }
+                            }
+                            //state is the writer
+                            //JsonSerializer.Serialize(state, scope);
+                        }
+                        else
+                        {
+                            state.WriteString("noName", scope.ToString());
+                        }
+                    }, (writer));
+                    writer.WriteEndObject();
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Console.WriteLine("Something went wrong" + ex.Message);
+            }
+        }
+
+        internal JsonConsoleLogFormatterOptions FormatterOptions { get; set; }
+
+        public IConsoleLogFormatterOptions UpdateWith(IConsoleLogFormatterOptions options)
+        {
+            if (options is JsonConsoleLogFormatterOptions jOptions)
+                FormatterOptions = jOptions;
+            else
+            {
+                FormatterOptions.IncludeScopes = options.IncludeScopes;
+                // etc.
+            }
+            return FormatterOptions;
+        }
+
+        private void ReloadLoggerOptions(JsonConsoleLogFormatterOptions options)
+        {
+            FormatterOptions = options;
+        }
+
+        public void Dispose()
+        {
+            _optionsReloadToken?.Dispose();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonConsoleLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonConsoleLogFormatterOptions.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    /// <summary>
+    /// Options for the built-in json console log formatter.
+    /// </summary>
+    public class JsonConsoleLogFormatterOptions : IConsoleLogFormatterOptions
+    {
+        public JsonConsoleLogFormatterOptions() { }
+
+        /// <summary>
+        /// Includes scopes when <see langword="true" />.
+        /// </summary>
+        public bool IncludeScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets JsonWriterOptions.
+        /// </summary>
+        public JsonWriterOptions JsonWriterOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets value indicating the minimum level of messages that would get written to <c>Console.Error</c>.
+        /// </summary>
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get; set; }
+        
+        /// <summary>
+        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// </summary>
+        public string TimestampFormat { get; set; }
+        
+        /// <summary>
+        /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
+        /// </summary>
+        public bool UseUtcTimestamp { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdConsoleLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdConsoleLogFormatter.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal class SystemdConsoleLogFormatter : IConsoleLogFormatter, IDisposable
+    {
+        private IDisposable _optionsReloadToken;
+
+        private static readonly string _loglevelPadding = ": ";
+        private static readonly string _messagePadding;
+
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+
+        static SystemdConsoleLogFormatter()
+        {
+            var logLevelString = GetSyslogSeverityString(LogLevel.Information);
+            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
+        }
+
+        public SystemdConsoleLogFormatter(IOptionsMonitor<SystemdConsoleLogFormatterOptions> options)
+        {
+            FormatterOptions = options.CurrentValue;
+            ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = options.OnChange(ReloadLoggerOptions);
+        }
+
+        private void ReloadLoggerOptions(SystemdConsoleLogFormatterOptions options)
+        {
+            FormatterOptions = options;
+        }
+
+        public void Dispose()
+        {
+            _optionsReloadToken?.Dispose();
+        }
+
+        public string Name => ConsoleLogFormatterNames.Systemd;
+
+        internal SystemdConsoleLogFormatterOptions FormatterOptions { get; set; }
+
+        public IConsoleLogFormatterOptions UpdateWith(IConsoleLogFormatterOptions options)
+        {
+            if (options is SystemdConsoleLogFormatterOptions jOptions)
+                FormatterOptions = jOptions;
+            else
+            {
+                FormatterOptions.IncludeScopes = options.IncludeScopes;
+                // etc.
+            }
+            return FormatterOptions;
+        }
+
+        public void Format<TState>(LogLevel logLevel, string logName, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter, IExternalScopeProvider scopeProvider, IConsoleMessageBuilder consoleMessageBuilder)
+        {
+            var message = formatter(state, exception);
+            if (string.IsNullOrEmpty(message) && exception == null)
+            {
+                return;
+            }
+            var logBuilder = _logBuilder;
+            _logBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+
+            // systemd reads messages from standard out line-by-line in a '<pri>message' format.
+            // newline characters are treated as message delimiters, so we must replace them.
+            // Messages longer than the journal LineMax setting (default: 48KB) are cropped.
+            // Example:
+            // <6>ConsoleApp.Program[10] Request received
+
+            // loglevel
+            var logLevelString = GetSyslogSeverityString(logLevel);
+            logBuilder.Append(logLevelString);
+
+            // timestamp
+            var timestampFormat = FormatterOptions.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime();
+                logBuilder.Append(dateTime.ToString(timestampFormat));
+            }
+
+            // category and event id
+            logBuilder.Append(logName);
+            logBuilder.Append("[");
+            logBuilder.Append(eventId.Id);
+            logBuilder.Append("]");
+
+            // scope information
+            GetScopeInformation(logBuilder, scopeProvider);
+
+            // message
+            if (!string.IsNullOrEmpty(message))
+            {
+                logBuilder.Append(' ');
+                // message
+                AppendAndReplaceNewLine(logBuilder, message);
+            }
+
+            // exception
+            // System.InvalidOperationException at Namespace.Class.Function() in File:line X
+            if (exception != null)
+            {
+                logBuilder.Append(' ');
+                AppendAndReplaceNewLine(logBuilder, exception.ToString());
+            }
+
+            // newline delimiter
+            logBuilder.Append(Environment.NewLine);
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+            
+            consoleMessageBuilder.LogAsError =  logLevel >= FormatterOptions.LogToStandardErrorThreshold;
+            consoleMessageBuilder
+                .Append(formattedMessage)
+                .Build();
+
+            static void AppendAndReplaceNewLine(StringBuilder sb, string message)
+            {
+                var len = sb.Length;
+                sb.Append(message);
+                sb.Replace(Environment.NewLine, " ", len, message.Length);
+            }
+        }
+
+        private DateTime GetCurrentDateTime()
+        {
+            return FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        }
+
+        private static string GetSyslogSeverityString(LogLevel logLevel)
+        {
+            // 'Syslog Message Severities' from https://tools.ietf.org/html/rfc5424.
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                    return "<7>"; // debug-level messages
+                case LogLevel.Information:
+                    return "<6>"; // informational messages
+                case LogLevel.Warning:
+                    return "<4>"; // warning conditions
+                case LogLevel.Error:
+                    return "<3>"; // error conditions
+                case LogLevel.Critical:
+                    return "<2>"; // critical conditions
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private void GetScopeInformation(StringBuilder stringBuilder, IExternalScopeProvider scopeProvider)
+        {
+            if (FormatterOptions.IncludeScopes && scopeProvider != null)
+            {
+                var initialLength = stringBuilder.Length;
+
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    var (builder, paddAt) = state;
+                    var padd = paddAt == builder.Length;
+                    if (padd)
+                    {
+                        builder.Append(_messagePadding);
+                        builder.Append("=> ");
+                    }
+                    else
+                    {
+                        builder.Append(" => ");
+                    }
+                    builder.Append(scope);
+                }, (stringBuilder, -1));
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdConsoleLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdConsoleLogFormatterOptions.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    /// <summary>
+    /// Options for the built-in systemd console log formatter.
+    /// </summary>
+    public class SystemdConsoleLogFormatterOptions : IConsoleLogFormatterOptions
+    {
+        public SystemdConsoleLogFormatterOptions() { }
+
+        /// <summary>
+        /// Includes scopes when <see langword="true" />.
+        /// </summary>
+        public bool IncludeScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets value indicating the minimum level of messages that would get written to <c>Console.Error</c>.
+        /// </summary>
+        public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get; set; }
+        
+        /// <summary>
+        /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
+        /// </summary>
+        public string TimestampFormat { get; set; }
+        
+        /// <summary>
+        /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
+        /// </summary>
+        public bool UseUtcTimestamp { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsoleMessageBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsoleMessageBuilder.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public interface IConsoleMessageBuilder
+    {
+        IConsoleMessageBuilder ResetColor();
+        IConsoleMessageBuilder SetColor(ConsoleColor? background, ConsoleColor?  foreground);
+        IConsoleMessageBuilder Append(string message);
+        IConsoleMessageBuilder Build();
+        void Clear();
+        bool LogAsError { get; set; }
+    }
+
+    internal readonly struct LME
+    {
+        public LME(string message, ConsoleColor? background = null, ConsoleColor? foreground = null, ColoredMessage? prev = null)
+        {
+            Current = new ColoredMessage(message, background, foreground);
+            Previous = prev;
+        }
+        public readonly ColoredMessage Current;
+        public readonly ColoredMessage? Previous;
+    }
+
+    internal readonly struct ColoredMessage
+    {
+        public ColoredMessage(string message, ConsoleColor? background = null, ConsoleColor? foreground = null)
+        {
+            Message = message;
+            Background = background;
+            Foreground = foreground;
+        }
+        public readonly string Message;
+        public readonly ConsoleColor? Background;
+        public readonly ConsoleColor? Foreground;
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
@@ -27,4 +27,30 @@ namespace Microsoft.Extensions.Logging.Console
         public readonly string Message;
         public readonly bool LogAsError;
     }
+    internal readonly struct LogMessageEntry2
+    {
+        public LogMessageEntry2(ConsoleMessage[] messages, bool logAsError = false)
+        {
+            Messages = messages;
+            LogAsError = logAsError;
+        }
+
+        public readonly ConsoleMessage[] Messages;
+        public readonly bool LogAsError;
+    }
+
+    internal readonly struct ConsoleMessage
+    {
+        public ConsoleMessage(string message, ConsoleColor? background = null, ConsoleColor? foreground = null, bool logAsError = false)
+        {
+            Message = message;
+            Background = background;
+            Foreground = foreground;
+            LogAsError = logAsError;
+        }
+        public readonly string Message;
+        public readonly ConsoleColor? Background;
+        public readonly ConsoleColor? Foreground;
+        public readonly bool LogAsError;
+    }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -24,11 +24,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Collections" />
+    <Reference Include="System.Linq" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Memory" />
+    <Reference Include="System.Text.Json" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Configuration.Binder" />
+    <Reference Include="Microsoft.Extensions.Configuration.Json" />
+    <Reference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION

Main things to note in V2 proposal: 
-	[x] Options:
	Any console log formatter option (custom or built-in) would implement IConsoleLogFormatterOptions
-	[x] Format:
	No need to expose LogMessageEntry anymore or to allocate arrays in IConsoleLogFormatter.Format(..). Exposing an IConsoleMessageBuilder instead
-	[x] Deprecations:
        Proposing to deprecate ConsoleLogProvider and ConsoleLoggerOptions entirely rather than only parts of it and introducing FormattedConsoleLogProvider and FormattedConsoleLoggerOptions. Could be less confusing and easier to maintain.
