### PR TITLE
ConfigurationBinder - Attempts to bind the configuration.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.Configuration
     }
     public static partial class ConfigurationBinder
     {
+        // Train for PR
         public static void Bind(this Microsoft.Extensions.Configuration.IConfiguration configuration, object instance) { }
         public static void Bind(this Microsoft.Extensions.Configuration.IConfiguration configuration, object instance, System.Action<Microsoft.Extensions.Configuration.BinderOptions> configureOptions) { }
         public static void Bind(this Microsoft.Extensions.Configuration.IConfiguration configuration, string key, object instance) { }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class ConfigurationBinder
     {
+        // Train for PR
         /// <summary>
         /// Attempts to bind the configuration instance to a new instance of type T.
         /// If this configuration section has a value, that will be used.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
         public class DerivedOptions : ComplexOptions
         {
+            // Train for PR
             public override string Virtual
             {
                 get


### PR DESCRIPTION
binds strongly typed objects to configuration values.
BinderOptions

- multidimensional arrays are not supported
- it is missing a public parameterless constructor