### PR TITLE
CommandLine Configuration Extension methods

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/ref/Microsoft.Extensions.Configuration.CommandLine.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Configuration
 }
 namespace Microsoft.Extensions.Configuration.CommandLine
 {
+    // Train for PR
     public partial class CommandLineConfigurationProvider : Microsoft.Extensions.Configuration.ConfigurationProvider
     {
         public CommandLineConfigurationProvider(System.Collections.Generic.IEnumerable<string> args, System.Collections.Generic.IDictionary<string, string> switchMappings = null) { }

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration.CommandLine;
 
 namespace Microsoft.Extensions.Configuration
 {
+    // Train for PR
     /// <summary>
     /// Extension methods for registering <see cref="CommandLineConfigurationProvider"/> with <see cref="IConfigurationBuilder"/>.
     /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/src/CommandLineConfigurationSource.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine
     /// </summary>
     public class CommandLineConfigurationSource : IConfigurationSource
     {
+        // Train for PR
         /// <summary>
         /// Gets or sets the switch mappings.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/CommandLineTest.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Configuration.CommandLine.Test
         [Fact]
         public void IgnoresOnlyUnknownArgs()
         {
+            // Train for PR
             var args = new string[]
                 {
                     "foo",

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/ConfigurationProviderCommandLineTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/tests/ConfigurationProviderCommandLineTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Configuration.CommandLine.Test
 {
+    // Train for PR
     public class ConfigurationProviderCommandLineTest : ConfigurationProviderTestBase
     {
         protected override (IConfigurationProvider Provider, Action Initializer) LoadThroughProvider(


### PR DESCRIPTION
CommandLineConfigurationProvider

CommandLineConfigurationExtensions

CommandLineConfigurationSource IConfigurationProvider

The values passed on the command line,
AddCommandLine 
CommandLineConfigurationSource SwitchMappings

```c#
        ///     // dotnet run -k1=value1 -k2 value2 --alt3=value2 /alt4=value3 --alt5 value5 /alt6 value6
        ///     
        ///     using Microsoft.Extensions.Configuration;
        ///     using System;
        ///     using System.Collections.Generic;
        ///     
        ///     namespace CommandLineSample
        ///     {
        ///        public class Program
        ///        {
        ///            public static void Main(string[] args)
        ///            {
        ///                var switchMappings = new Dictionary&lt;string, string&gt;()
        ///                {
        ///                    { "-k1", "key1" },
        ///                    { "-k2", "key2" },
        ///                    { "--alt3", "key3" },
        ///                    { "--alt4", "key4" },
        ///                    { "--alt5", "key5" },
        ///                    { "--alt6", "key6" },
        ///                };
        ///                var builder = new ConfigurationBuilder();
        ///                builder.AddCommandLine(args, switchMappings);
        ///     
        ///                var config = builder.Build();
        ///     
        ///                Console.WriteLine($"Key1: '{config["Key1"]}'");
        ///                Console.WriteLine($"Key2: '{config["Key2"]}'");
        ///                Console.WriteLine($"Key3: '{config["Key3"]}'");
        ///                Console.WriteLine($"Key4: '{config["Key4"]}'");
        ///                Console.WriteLine($"Key5: '{config["Key5"]}'");
        ///                Console.WriteLine($"Key6: '{config["Key6"]}'");
        ///            }
        ///        }
        ///     }
```

reads configuration values from the command line.

The switch mappings. A dictionary of short (with prefix "-") and alias keys (with prefix "--"), mapped to the configuration key (no prefix).

```
dotnet run key1=value1 --key2=value2 /key3=value3 --key4 value4 /key5 value5
        ///     using Microsoft.Extensions.Configuration;
        ///     using System;
        ///     
        ///     namespace CommandLineSample
        ///     {
        ///        public class Program
        ///        {
        ///            public static void Main(string[] args)
        ///            {
        ///                var builder = new ConfigurationBuilder();
        ///                builder.AddCommandLine(args);
        ///     
        ///                var config = builder.Build();
        ///     
        ///                Console.WriteLine($"Key1: '{config["Key1"]}'");
        ///                Console.WriteLine($"Key2: '{config["Key2"]}'");
        ///                Console.WriteLine($"Key3: '{config["Key3"]}'");
        ///                Console.WriteLine($"Key4: '{config["Key4"]}'");
        ///                Console.WriteLine($"Key5: '{config["Key5"]}'");
        ///            }
        ///        }
        ///     }
```
