### PR TITLE
Adds FileLoadExceptionContext

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/ref/Microsoft.Extensions.Configuration.FileExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Configuration
 {
     public static partial class FileConfigurationExtensions
     {
+        // Train for PR
         public static System.Action<Microsoft.Extensions.Configuration.FileLoadExceptionContext> GetFileLoadExceptionHandler(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
         public static Microsoft.Extensions.FileProviders.IFileProvider GetFileProvider(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder SetBasePath(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string basePath) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class FileConfigurationExtensions
     {
+        // Train for PR
         private static string FileProviderKey = "FileProvider";
         private static string FileLoadExceptionHandlerKey = "FileLoadExceptionHandler";
 

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileLoadExceptionContext.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileLoadExceptionContext.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public class FileLoadExceptionContext
     {
+        // Train for PR
         /// <summary>
         /// The <see cref="FileConfigurationProvider"/> that caused the exception.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationBuilderExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationBuilderExtensionsTest.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
         [Fact]
         public void SetFileProvider_ThrowsIfBasePathIsNull()
         {
+            // Train for PR
             // Arrange
             var configurationBuilder = new ConfigurationBuilder();
 


### PR DESCRIPTION
FileLoadExceptionContext Contains information about a file load exception.

IConfigurationBuilder FileProviders
FileConfigurationProvider Load

If no file provider has been set, for absolute Path, this will creates a physical file provider for the nearest existing directory. PhysicalFileProvider