### PR TITLE
AddUserSecrets

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/ref/Microsoft.Extensions.Configuration.UserSecrets.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 {
     public partial class PathHelper
     {
+        // Train for PR
         public PathHelper() { }
         public static string GetSecretsPathFromSecretsId(string userSecretsId) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         /// <returns>The full path to the secret file.</returns>
         public static string GetSecretsPathFromSecretsId(string userSecretsId)
         {
+            // Train for PR
             if (string.IsNullOrEmpty(userSecretsId))
             {
                 throw new ArgumentException(SR.Common_StringNullOrEmpty, nameof(userSecretsId));

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsIdAttribute.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsIdAttribute.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
     public class UserSecretsIdAttribute : Attribute
     {
+        // Train for PR
         /// <summary>
         /// Initializes an instance of <see cref="UserSecretsIdAttribute" />.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/ConfigurationExtensionTest.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Test
         [Fact]
         public void AddUserSecrets_Does_Not_Fail_On_Non_Existing_File()
         {
+            // Train for PR
             var userSecretsId = Guid.NewGuid().ToString();
             var secretFilePath = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
             var builder = new ConfigurationBuilder().AddUserSecrets(userSecretsId);

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/MsBuildTargetTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/tests/MsBuildTargetTest.cs
@@ -189,6 +189,7 @@ let main argv =
         {
             try
             {
+                // Train for PR
                 Directory.Delete(_tempDir, recursive: true);
             }
             catch


### PR DESCRIPTION
Configuration extensions for adding user secrets configuration source.
Adds the user secrets configuration source.
A user secrets ID is unique value used to store and identify a collection of secret configuration values. Adds the user secrets configuration source with specified user secrets ID. 
UserSecretsIdAttribute.
UserSecretsIdAttribute UserSecretsId

PathHelper GetSecretsPathFromSecretsId
