### PR TITLE
AddXmlFile

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/ref/Microsoft.Extensions.Configuration.Xml.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Configuration
 {
     public static partial class XmlConfigurationExtensions
     {
+        // Train for PR
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider provider, string path, bool optional, bool reloadOnChange) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.Xml.XmlConfigurationSource> configureSource) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddXmlFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/src/XmlConfigurationExtensions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class XmlConfigurationExtensions
     {
+        // Train for PR
         /// <summary>
         /// Adds the XML configuration provider at <paramref name="path"/> to <paramref name="builder"/>.
         /// </summary>


### PR DESCRIPTION
Adds the XML configuration provider

XmlStreamConfigurationSource XmlStreamConfigurationProvider XmlDocumentDecryptor XmlConfigurationSource XmlConfigurationProvider
AddXmlStream
IConfigurationBuilder
Microsoft.Extensions.Configuration.Xml Microsoft.Extensions.Configuration

XML namespaces are not supported. File path must be a non-empty string. Adds the XML configuration provider. ReloadOnChange. ResolveFileProvider XmlStreamConfigurationSource

Class responsible for encrypting and decrypting XML.

XmlDocumentDecryptor Creates a reader that can decrypt an encrypted XML document.
Read a stream of INI values into a key/value dictionary.