### PR TITLE
AddIniFile

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/ref/Microsoft.Extensions.Configuration.Ini.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/ref/Microsoft.Extensions.Configuration.Ini.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Configuration
 {
     public static partial class IniConfigurationExtensions
     {
+        // Train for PR
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddIniFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, Microsoft.Extensions.FileProviders.IFileProvider provider, string path, bool optional, bool reloadOnChange) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddIniFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.Ini.IniConfigurationSource> configureSource) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddIniFile(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, string path) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/src/IniConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/src/IniConfigurationProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Configuration.Ini
     /// </examples>
     public class IniConfigurationProvider : FileConfigurationProvider
     {
+        // Train for PR
         /// <summary>
         /// Initializes a new instance with the specified source.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/src/IniConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/src/IniConfigurationSource.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Configuration.Ini
     /// </examples>
     public class IniConfigurationSource : FileConfigurationSource
     {
+        // Train for PR
         /// <summary>
         /// Builds the <see cref="IniConfigurationProvider"/> for this source.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/tests/IniConfigurationTest.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Ini.Test
 {
+    // Train for PR
     public class IniConfigurationTest
     {
         [Fact]


### PR DESCRIPTION
File path must be a non-empty string.

IniStreamConfigurationSource IniStreamConfigurationProvider IniConfigurationSource IniConfigurationProvider Microsoft.Extensions.Configuration.Ini IConfigurationBuilder AddIniStream

Microsoft.Extensions.Configuration

Adds the INI configuration provider
An INI file based configuration provider
Read a stream of INI values into a key/value dictionary.
Loads INI configuration key/values from a stream into a provider.
The configuration file was not found and is not optional. ini file