### PR TITLE
update to ConfigureAll - AddOptions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/ref/Microsoft.Extensions.Options.ConfigurationExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class OptionsBuilderConfigurationExtensions
     {
+        // Train for PR
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> Bind<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, Microsoft.Extensions.Configuration.IConfiguration config) where TOptions : class { throw null; }
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> Bind<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, Microsoft.Extensions.Configuration.IConfiguration config, System.Action<Microsoft.Extensions.Configuration.BinderOptions> configureBinder) where TOptions : class { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/src/ConfigureFromConfigurationOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/src/ConfigureFromConfigurationOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Options
     public class ConfigureFromConfigurationOptions<TOptions> : ConfigureOptions<TOptions>
         where TOptions : class
     {
+        // Train for PR
         /// <summary>
         /// Constructor that takes the <see cref="IConfiguration"/> instance to bind against.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/ref/Microsoft.Extensions.Options.DataAnnotations.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class OptionsBuilderDataAnnotationsExtensions
     {
+        // Train for PR
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> ValidateDataAnnotations<TOptions>(this Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder) where TOptions : class { throw null; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/src/DataAnnotationValidateOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions">The instance being validated.</typeparam>
     public class DataAnnotationValidateOptions<TOptions> : IValidateOptions<TOptions> where TOptions : class
     {
+        // Train for PR
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/ref/Microsoft.Extensions.Options.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static partial class OptionsServiceCollectionExtensions
     {
+        // Train for PR
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddOptions(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { throw null; }
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> AddOptions<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) where TOptions : class { throw null; }
         public static Microsoft.Extensions.Options.OptionsBuilder<TOptions> AddOptions<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string name) where TOptions : class { throw null; }

--- a/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/IConfigureOptions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions"></typeparam>
     public interface IConfigureOptions<in TOptions> where TOptions : class
     {
+        // Train for PR
         /// <summary>
         /// Invoked to configure a <typeparamref name="TOptions"/> instance.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Options/src/Options.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/Options.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Options
     /// </summary>
     public static class Options
     {
+        // Train for PR
         /// <summary>
         /// The default name used for options instances: "".
         /// </summary>


### PR DESCRIPTION
PostConfigure ConfigureOptions OptionsBuilder
ConfigureNamedOptions 
ValidateOptions PostConfigureOptions OptionsWrapper OptionsValidationException OptionsMonitor OptionsFactory OptionsManager OptionsCache OptionsBuilder ValidateOptionsResult IPostConfigureOptions IOptionsSnapshot IOptionsMonitorCache IOptionsFactory IOptionsChangeTokenSource IConfigureNamedOptions ConfigureNamedOptions OptionsServiceCollectionExtensions

implementations were found, did you mean to call Configure.
because it is missing a public parameterless constructor

OptionsBuilderConfigurationExtensions Bind OptionsConfigurationServiceCollectionExtensions ConfigurationChangeTokenSource ConfigureFromConfigurationOptions

OptionsBuilderDataAnnotationsExtensions DataAnnotationValidateOptions
Microsoft.Extensions.Options
DataAnnotation for validation

Validates a specific named options instance
Register this options instance for validation of its DataAnnotations.

Extension methods for adding configuration related options services to the DI container via OptionsBuilder

The name of the options instance being watched
The name of the option instance being changed.

Configures an option instance by using ConfigurationBuilder.Bind

Constructor that takes the <see cref="IConfiguration instance to bind against.
Registers a configuration instance which TOptions will bind against.

Null name is used to configure all named options.
Tries to adds a new option to the cache, will return false if the name already exists.
Try to remove an options instance.

ValidateOptionsResult

AddOptions Adds services required for using options.
Tries to adds a new option to the cache, will return false if the name already exists.