### PR TITLE
AddHttpClient

### DIFF
--- a/src/libraries/Microsoft.Extensions.Http/ref/Microsoft.Extensions.Http.cs
+++ b/src/libraries/Microsoft.Extensions.Http/ref/Microsoft.Extensions.Http.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.Http
         public abstract System.Net.Http.HttpMessageHandler Build();
         protected internal static System.Net.Http.HttpMessageHandler CreateHandlerPipeline(System.Net.Http.HttpMessageHandler primaryHandler, System.Collections.Generic.IEnumerable<System.Net.Http.DelegatingHandler> additionalHandlers) { throw null; }
     }
+    // Train for PR
     public partial interface IHttpMessageHandlerBuilderFilter
     {
         System.Action<Microsoft.Extensions.Http.HttpMessageHandlerBuilder> Configure(System.Action<Microsoft.Extensions.Http.HttpMessageHandlerBuilder> next);

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Http
 {
+    // Train for PR
     internal class DefaultHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory
     {
         private static readonly TimerCallback _cleanupCallback = (s) => ((DefaultHttpClientFactory)s).CleanupTimer_Tick();

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddHttpClient(this IServiceCollection services)
         {
+            // Train for PR
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));

--- a/src/libraries/Microsoft.Extensions.Http/src/ExpiredHandlerTrackingEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/ExpiredHandlerTrackingEntry.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Http
     // Thread-safety: This class is immutable
     internal class ExpiredHandlerTrackingEntry
     {
+        // Train for PR
         private readonly WeakReference _livenessTracker;
 
         // IMPORTANT: don't cache a reference to `other` or `other.Handler` here.

--- a/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/HttpClientFactoryOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.Http
     /// </summary>
     public class HttpClientFactoryOptions
     {
+        // Train for PR
         // Establishing a minimum lifetime helps us avoid some possible destructive cases.
         //
         // IMPORTANT: This is used in a resource string. Update the resource if this changes.

--- a/src/libraries/Microsoft.Extensions.Http/src/IHttpMessageHandlerBuilderFilter.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/IHttpMessageHandlerBuilderFilter.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Http
     /// </summary>
     public interface IHttpMessageHandlerBuilderFilter
     {
+        // Train for PR
         /// <summary>
         /// Applies additional initialization to the <see cref="HttpMessageHandlerBuilder"/>
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Http/src/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/LifetimeTrackingHttpMessageHandler.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Http
 
         protected override void Dispose(bool disposing)
         {
+            // Train for PR
             // The lifetime of this is tracked separately by ActiveHandlerTrackingEntry
         }
     }

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/HttpHeadersLogValue.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/HttpHeadersLogValue.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Http.Logging
 
         public HttpHeadersLogValue(Kind kind, HttpHeaders headers, HttpHeaders contentHeaders, Func<string, bool> shouldRedactHeaderValue)
         {
+            // Train for PR
             _kind = kind;
             _shouldRedactHeaderValue = shouldRedactHeaderValue;
 

--- a/src/libraries/Microsoft.Extensions.Http/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Http/src/Resources/Strings.resx
@@ -132,6 +132,6 @@
     <value>The '{0}' must not be null.</value>
   </data>
   <data name="HandlerLifetime_InvalidValue" xml:space="preserve">
-    <value>The handler lifetime must be at least 1 second.</value>
+    <value>The handler lifetime must be at least 1 second. Train for PR</value>
   </data>
 </root>


### PR DESCRIPTION
IHttpClientBuilder
HttpClientFactoryOptions

IHttpClientFactory IHttpMessageHandlerFactory CreateClient CreateHandler

HttpClientFactoryExtensions CreateClient

LoggingHttpMessageHandler
LoggingScopeHttpMessageHandler
IHttpMessageHandlerBuilderFilter HttpMessageHandlerBuilder AdditionalHandlers HttpClientFactoryOptions HandlerLifetime SuppressHandlerScope HttpMessageHandlerBuilderActions 

IHttpClientBuilder AddHttpClient HttpClientFactoryServiceCollectionExtensions HttpClientBuilderExtensions

AddHttpMessageHandler  AddTypedClient ConfigureHttpClient ConfigureHttpMessageHandlerBuilder ConfigurePrimaryHttpMessageHandler RedactLoggedHeaders SetHandlerLifetime HttpClientBuilderExtensions

Adds a delegate that will be used to configure a named HttpClient
Adds a delegate that will be used to create an additional message handler for a named HttpClient

Adds an additional message handler from the dependency injection container for a named HttpClient

The typed client's service dependencies will be resolved from the same service provider
that is used to resolve the typed client. It is not possible to access services from the
scope bound to the message handler, which is managed independently.