### PR TITLE
Bugfix on BackgroundService.StartAsync

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Hosting
     /// </summary>
     public abstract class BackgroundService : IHostedService, IDisposable
     {
+        // Train for PR
         private Task _executingTask;
         private CancellationTokenSource _stoppingCts;
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/TestApp/Program.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/TestApp/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ServerComparison.TestSites
 {
+    // Train for PR
     public static class Program
     {
         public static void Main(string[] args)

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Fakes/FakeHostedService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Fakes/FakeHostedService.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Hosting.Tests.Fakes
 {
     public class FakeHostedService : IHostedService, IDisposable
     {
+        // Train for PR
         public int StartCount { get; internal set; }
         public int StopCount { get; internal set; }
         public int DisposeCount { get; internal set; }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Hosting
 {
     public partial class HostTests
     {
+        // Train for PR
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34580", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void CreateDefaultBuilder_IncludesContentRootByDefault()


### PR DESCRIPTION
Triggered when the application host is ready to start the service.

IHostedService IHostLifetime Microsoft.Extensions.Hosting
EnvironmentName ApplicationName IHostingEnvironment 

Gets or sets the absolute path to the directory that contains the application content files.
ContentRootPath

IHostEnvironment IHostedService IHostBuilder

IHostApplicationLifetime Allows consumers to be notified of application lifetime events. This interface is not intended to be user-replaceable

IHost StopAsync Used to indicate when stop should no longer be graceful
Attempts to gracefully stop the program.

IApplicationLifetime Allows consumers to perform cleanup during a graceful shutdown. 
ApplicationStarted Triggered when the application host has fully started and is about to wait for a graceful shutdown

HostingEnvironmentExtensions
IsStaging IsProduction IsEnvironment

WaitForShutdown
Runs an application and block the calling thread until host shutdown.

RunAsync Runs an application and returns a Task that only completes when the token is triggered or shutdown is triggered.

WaitForShutdownAsync

Checks if the current hosting environment name is EnvironmentName.Development IsDevelopment

ContentRootKey ApplicationKey EnvironmentKey
HostingEnvironment

Provides convenience methods for creating instances of IHostBuilder
UseDefaultServiceProvider

ConfigureHostConfiguration ConfigureAppConfiguration UseServiceProviderFactory
UseEnvironment

HostFactoryResolver