### PR TITLE
MemoryCache and MemoryCacheOptions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Caching.Distributed
 {
     public static partial class DistributedCacheEntryExtensions
     {
+        // PR for training
         public static Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions SetAbsoluteExpiration(this Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions options, System.DateTimeOffset absolute) { throw null; }
         public static Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions SetAbsoluteExpiration(this Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions options, System.TimeSpan relative) { throw null; }
         public static Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions SetSlidingExpiration(this Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions options, System.TimeSpan offset) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/CacheEntryExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Caching.Memory
             this ICacheEntry entry,
             CacheItemPriority priority)
         {
+            // Train for PR
             entry.Priority = priority;
             return entry;
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheEntryOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheEntryOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Caching.Memory
     /// </summary>
     public class MemoryCacheEntryOptions
     {
+        // Train for PR
         private DateTimeOffset? _absoluteExpiration;
         private TimeSpan? _absoluteExpirationRelativeToNow;
         private TimeSpan? _slidingExpiration;

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Caching.Distributed
 {
     public partial class MemoryDistributedCache : Microsoft.Extensions.Caching.Distributed.IDistributedCache
     {
+        // Train for PR
         public MemoryDistributedCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryDistributedCacheOptions> optionsAccessor) { }
         public MemoryDistributedCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryDistributedCacheOptions> optionsAccessor, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public byte[] Get(string key) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Caching.Memory
         [Fact]
         public void MemoryDistributedCacheOptionsDefaultsTo200MBSizeLimit()
         {
+            // Train for PR
             Assert.Equal(200 * 1024 * 1024, new MemoryDistributedCacheOptions().SizeLimit);
         }
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Infrastructure/TestExpirationToken.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Infrastructure/TestExpirationToken.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Caching.Memory.Infrastructure
 {
     internal class TestExpirationToken : IChangeToken
     {
+        // Train for PR
         private bool _hasChanged;
         private bool _activeChangeCallbacks;
 

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/TokenExpirationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/TokenExpirationTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.Caching.Memory
     {
         private IMemoryCache CreateCache()
         {
+            // Train for PR
             return CreateCache(new SystemClock());
         }
 


### PR DESCRIPTION
 Fix the cache options applied to a memory cache instance

SetAbsoluteExpiration SetSlidingExpiration DistributedCacheEntryOptions 
AbsoluteExpirationRelativeToNow DistributedCacheExtensions IDistributedCache Microsoft.Extensions.Caching.Memory CacheEntryExtensions 

AddExpirationToken CacheExtensions CacheItemPriority ICacheEntry AbsoluteExpirationRelativeToNow MemoryCacheEntryExtensions

AddExpirationToken MemoryCacheEntryOptions PostEvictionCallbackRegistration PostEvictionDelegate SystemClock

MemoryDistributedCache MemoryCacheServiceCollectionExtensions AddDistributedMemoryCache
AddMemoryCache

MemoryDistributedCacheOptions MemoryCacheOptions

Sets the priority for keeping the cache entry in the cache during a memory pressure tokened cleanup.
Expire the cache entry if the given IChangeToken expires.

RegisterPostEvictionCallback 
Sets the size of the cache entry value.

Specifies how items are prioritized for preservation during a memory pressure triggered cleanup.
EvictionReason
Represents a distributed cache of serialized values.
Refreshes a value in the cache based on its key, resetting its sliding expiration timeout 

Sets the priority for keeping the cache entry in the cache during a memory pressure tokened cleanup.
RegisterPostEvictionCallback SetSlidingExpiration
CacheExtensions
MemoryDistributedCacheOptions
