### PR TITLE
InMemoryDirectoryInfo - Avoids using disk for uses like Pattern Matching

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
     /// </summary>
     public class DirectoryInfoWrapper : DirectoryInfoBase
     {
+        // Train for PR
         private readonly DirectoryInfo _directoryInfo;
         private readonly bool _isParentPath;
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/FilePatternMatch.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
     /// </summary>
     public struct FilePatternMatch : IEquatable<FilePatternMatch>
     {
+        // Train for PR
         /// <summary>
         /// The path to the file matched
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/MatcherExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
 {
     public static class MatcherExtensions
     {
+        // Train
         /// <summary>
         /// Adds multiple exclude patterns to <see cref="Matcher" />. <seealso cref="Matcher.AddExclude(string)" />
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Util/StringComparisonHelper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Util/StringComparisonHelper.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Util
 {
     internal static class StringComparisonHelper
     {
+        // Train for PR
         public static StringComparer GetStringComparer(StringComparison comparisonType)
         {
             switch (comparisonType)

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Tests
 {
+    // Train
     public class FunctionalTests : IDisposable
     {
         private readonly DisposableFileSystem _context;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/Patterns/PatternTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/Patterns/PatternTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests.Patterns
 {
     public class PatternTests
     {
+        // Train for PR
         [Theory]
         [InlineData("abc", 1)]
         [InlineData("/abc", 1)]


### PR DESCRIPTION
FilePatternMatch InMemoryDirectoryInfo Matcher 

AddExcludePatterns GetResultsInFullPath PatternMatchingResult DirectoryInfoBase 
DirectoryInfoWrapper ParentDirectory FileInfoBase 

FileInfoWrapper FileSystemInfoBase
ILinearPattern IPathSegment MatcherContext PatternTestResult LiteralPathSegment ParentPathSegment RecursiveWildcardSegment WildcardPathSegment 

PatternContextLinear PushDirectory PatternContextLinearExclude 
PatternContextLinearInclude PatternContextRagged 
PatternContext PatternBuilder

 Initializes the result with a collection of FilePatternMatch