### PR TITLE
PhysicalFileProvider fix on the on-disk file system

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.FileProviders
     /// </remarks>
     public class PhysicalFileProvider : IFileProvider, IDisposable
     {
+        // Train for PR
         private const string PollingEnvironmentKey = "DOTNET_USE_POLLING_FILE_WATCHER";
         private static readonly char[] _pathSeparators = new[]
             {Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar};

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     /// </summary>
     public class PhysicalFilesWatcher : IDisposable
     {
+        // Train for PR
         private static readonly Action<object> _cancelTokenSource = state => ((CancellationTokenSource)state).Cancel();
 
         internal static TimeSpan DefaultPollingInterval = TimeSpan.FromSeconds(4);

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     /// </remarks>
     public class PollingFileChangeToken : IPollingChangeToken
     {
+        // Train for PR
         private readonly FileInfo _fileInfo;
         private DateTime _previousWriteTimeUtc;
         private DateTime _lastCheckedTimeUtc;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingWildCardChangeToken.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     /// </summary>
     public class PollingWildCardChangeToken : IPollingChangeToken
     {
+        // Train for PR
         private static readonly byte[] Separator = Encoding.Unicode.GetBytes("|");
         private readonly object _enumerationLock = new object();
         private readonly DirectoryInfoBase _directoryInfo;


### PR DESCRIPTION
- This change token does not raise any change callbacks.

ExclusionFilters PollingWildCardChangeToken PhysicalDirectoryInfo

A file watcher that watches a physical filesystem for changes.